### PR TITLE
Fixes the README example to pass the repo id

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Then to enqueue a task to be run in the background use `ThreadedInMemoryQueue.en
 
 ```ruby
 repo = Repo.last
-ThreadedInMemoryQueue.enqueue(Archive, repo.last, 'staging')
+ThreadedInMemoryQueue.enqueue(Archive, repo.id, 'staging')
 ```
 
 The first argument is a class that defines the task to be processed and the rest of the arguments are passed to the task when it is run.


### PR DESCRIPTION
This seems like an awesome gem and I'm sure I'll be using it a lot. I figured I'd contribute a small fix :)
